### PR TITLE
libusbgx conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ IF(BUILD_EXECUTABLE)
 	SET(DATADIR "${PREFIX}/share/${PACKAGE}/data")
 
 	SET(PKG_MODULES
-		libusbg
+		libusbgx
 		glib-2.0
 		libconfig
 		gio-unix-2.0

--- a/packaging/gadgetd.spec
+++ b/packaging/gadgetd.spec
@@ -9,7 +9,7 @@ Source1001:     gadgetd.manifest
 BuildRequires:  cmake
 BuildRequires:  pkg-config
 BuildRequires:  pkgconfig(glib-2.0)
-BuildRequires:  pkgconfig(libusbg)
+BuildRequires:  pkgconfig(libusbgx)
 
 %description
 Gadgetd is a tool for USB gadget management.

--- a/src/dbus-function-ifaces/gadgetd-serial-function-iface.c
+++ b/src/dbus-function-ifaces/gadgetd-serial-function-iface.c
@@ -16,6 +16,11 @@
  */
 
 #include <usbg/usbg.h>
+#include <usbg/function/ms.h>
+#include <usbg/function/net.h>
+#include <usbg/function/ffs.h>
+#include <usbg/function/phonet.h>
+#include <usbg/function/midi.h>
 #include <stdio.h>
 #include <gio/gio.h>
 #include <gadgetd-common.h>
@@ -109,7 +114,15 @@ function_serial_attrs_get_property(GObject    *object,
 	FunctionSerialAttrs *serial_attrs = FUNCTION_SERIAL_ATTRS(object);
 	GadgetdFunctionObject *function_object;
 	usbg_function *f;
-	usbg_function_attrs f_attrs;
+	/* FIXME: find a better solution to a union here? */
+	union {
+		struct usbg_f_net_attrs net;
+		char *ffs_dev_name;
+		struct usbg_f_ms_attrs ms;
+		struct usbg_f_midi_attrs midi;
+		int serial_port_num;
+		char *phonet_ifname;
+	} f_attrs;
 
 	function_object = function_serial_attrs_get_function_object(serial_attrs);
 
@@ -128,7 +141,7 @@ function_serial_attrs_get_property(GObject    *object,
 
 	switch(property_id) {
 	case PROP_SERIAL_PORTNUM:
-		g_value_set_int(value, f_attrs.serial.port_num);
+		g_value_set_int(value, f_attrs.serial_port_num);
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);

--- a/src/gadgetd-functions.c
+++ b/src/gadgetd-functions.c
@@ -154,7 +154,7 @@ gd_register_kernel_funcs()
 	for (func = functions; *func; ++func) {
 		func_type = usbg_lookup_function_type(*func);
 		if (func_type < 0) {
-			/* If this function is not supported by libusbg we
+			/* If this function is not supported by libusbgx we
 			 * will be unable to create its instance but it's not
 			 * a reason to report an error. Just don't register it
 			 * so it won't be available through gadgetd API


### PR DESCRIPTION
Since libusbg has been replaced by libusbgx and since libusbgx has changed away from using usbg_function_attrs type, a few small changes are needed in order to have gadgetd compile correctly.

I'm unclear about the union added into gadgetd-serial-function-iface.c, it seems like this "type" should be a typedef which comes from libusbgx, but none seems to exist.  This scares me as it appears fragile, but I haven't looked into the code in libusbgx enough to understand it well.
