### PR TITLE
gadgetd: example: Ensure gd_get_ep_by_nmb() is callable

### DIFF
--- a/examples/ffs-service-example.c
+++ b/examples/ffs-service-example.c
@@ -59,6 +59,8 @@
 
 /******************** Endpoints handling *******************************/
 
+extern int gd_get_ep_by_nmb(int nmb);
+
 static void display_event(struct usb_functionfs_event *event)
 {
 	static const char *const names[] = {


### PR DESCRIPTION
Since gd_get_ep_by_nmb() is an inline function, declare it as an extern
in the ffs-service-example.c example code so that the compiler/linker
can find it correctly and without error.

Signed-off-by: Andrew Bradford andrew.bradford@kodakalaris.com
