### PR TITLE
Libusbgx conversion v3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ IF(BUILD_EXECUTABLE)
 	SET(DATADIR "${PREFIX}/share/${PACKAGE}/data")
 
 	SET(PKG_MODULES
-		libusbg
+		libusbgx
 		glib-2.0
 		libconfig
 		gio-unix-2.0

--- a/packaging/gadgetd.spec
+++ b/packaging/gadgetd.spec
@@ -9,7 +9,7 @@ Source1001:     gadgetd.manifest
 BuildRequires:  cmake
 BuildRequires:  pkg-config
 BuildRequires:  pkgconfig(glib-2.0)
-BuildRequires:  pkgconfig(libusbg)
+BuildRequires:  pkgconfig(libusbgx)
 
 %description
 Gadgetd is a tool for USB gadget management.

--- a/src/dbus-function-ifaces/gadgetd-serial-function-iface.c
+++ b/src/dbus-function-ifaces/gadgetd-serial-function-iface.c
@@ -16,6 +16,7 @@
  */
 
 #include <usbg/usbg.h>
+#include <usbg/function/serial.h>
 #include <stdio.h>
 #include <gio/gio.h>
 #include <gadgetd-common.h>
@@ -109,7 +110,8 @@ function_serial_attrs_get_property(GObject    *object,
 	FunctionSerialAttrs *serial_attrs = FUNCTION_SERIAL_ATTRS(object);
 	GadgetdFunctionObject *function_object;
 	usbg_function *f;
-	usbg_function_attrs f_attrs;
+	usbg_f_serial *f_serial;
+	int port_num;
 
 	function_object = function_serial_attrs_get_function_object(serial_attrs);
 
@@ -120,15 +122,16 @@ function_serial_attrs_get_property(GObject    *object,
 		return;
 	}
 
-	usbg_ret = usbg_get_function_attrs(f, &f_attrs);
-	if (usbg_ret != USBG_SUCCESS) {
-		ERROR("Cant get function attributes");
-		return;
-	}
+	f_serial = usbg_to_serial_function(f);
 
 	switch(property_id) {
 	case PROP_SERIAL_PORTNUM:
-		g_value_set_int(value, f_attrs.serial.port_num);
+		usbg_ret = usbg_f_serial_get_port_num(f_serial, &port_num);
+		if (usbg_ret != USBG_SUCCESS) {
+			ERROR("Cant get serial port number");
+			return;
+		}
+		g_value_set_int(value, port_num);
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID(object, property_id, pspec);

--- a/src/gadgetd-functions.c
+++ b/src/gadgetd-functions.c
@@ -154,7 +154,7 @@ gd_register_kernel_funcs()
 	for (func = functions; *func; ++func) {
 		func_type = usbg_lookup_function_type(*func);
 		if (func_type < 0) {
-			/* If this function is not supported by libusbg we
+			/* If this function is not supported by libusbgx we
 			 * will be unable to create its instance but it's not
 			 * a reason to report an error. Just don't register it
 			 * so it won't be available through gadgetd API


### PR DESCRIPTION
Changes from v2: Move port number getter into the PROP_SERIAL_PORTNUM case.
Changes from v1: Use libusbgx usbg_f_serial_get_port_num() function rather than ugly and fragile union.
