### PR TITLE
gadgetd: ffs-daemon.h: Ensure gd_get_ep_by_nmb() is callable

### DIFF
--- a/include/ffs-daemon.h
+++ b/include/ffs-daemon.h
@@ -50,6 +50,7 @@ int gd_get_ep_nmb(int ep_fd);
   You should not call this function with
   nmb >= gd_nmb_of_eps
  */
+extern int gd_get_ep_by_nmb(int nmb);
 inline int gd_get_ep_by_nmb(int nmb)
 {
 	return GD_ENDPOINT_FDS_START + nmb;


### PR DESCRIPTION
Without declaring gd_get_ep_by_nmb() with extern, since it is an inline
function, the linker may not always be able to find it correctly,
resulting in linking failures like are exposed by the
ffs-service-example example code:

[ 93%] Linking C executable ffs-service-example
CMakeFiles/ffs-service-example.dir/ffs-service-example.c.o: In function `main':
/home/andrew/git/gadgetd/examples/ffs-service-example.c:152: undefined reference to`gd_get_ep_by_nmb'
collect2: error: ld returned 1 exit status

Declare gd_get_ep_by_nmb() as extern prior to defining it as an inline
function.  GCC docs recommend this [1](https://gcc.gnu.org/onlinedocs/gcc/Inline.html).

Signed-off-by: Andrew Bradford andrew.bradford@kodakalaris.com
